### PR TITLE
Add support for displaying Spell Points in Tidy5e Sheet

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -21,6 +21,7 @@ class VSpellPoints {
     }
 
     static CUSTOM_SHEETS = {
+        DEFAULT: "ActorSheet5eCharacter",
         TIDY5E: "Tidy5eSheet"
     }
 
@@ -49,8 +50,17 @@ class VSpellPoints {
 
     static initialize() {
         // load templates
-        delete _templateCache[this.TEMPLATES.ATTRIBUTE];
-        loadTemplates([this.TEMPLATES.ATTRIBUTE]);
+        delete _templateCache[this.TEMPLATES.LEVELS_TOOLTIP];
+        delete _templateCache[this.TEMPLATES.ActorSheet5eCharacter.ATTRIBUTE];
+        delete _templateCache[this.TEMPLATES.ActorSheet5eCharacter.RESOURCE];
+        delete _templateCache[this.TEMPLATES.Tidy5eSheet.ATTRIBUTE];
+        delete _templateCache[this.TEMPLATES.Tidy5eSheet.RESOURCE];
+
+        loadTemplates([this.TEMPLATES.LEVELS_TOOLTIP,
+            this.TEMPLATES.ActorSheet5eCharacter.ATTRIBUTE,
+            this.TEMPLATES.ActorSheet5eCharacter.RESOURCE,
+            this.TEMPLATES.Tidy5eSheet.ATTRIBUTE,
+            this.TEMPLATES.Tidy5eSheet.RESOURCE]);
 
         // disable module if unsupported module is active
         if (this.unsupportedModuleActive()) {
@@ -428,7 +438,7 @@ class VSpellPointsCalcs {
         return this._spellPointsByLevelTable[clampedLevel];
     }
 
-    static async createSpellPointsInfo(actor, data, asResource=false, sheetTheme='ActorSheet5eCharacter') {
+    static async createSpellPointsInfo(actor, data, asResource, sheetTheme) {
         // read from actor
         /** @type Resource */
         let userData = data;
@@ -458,6 +468,10 @@ class VSpellPointsCalcs {
             asResource,
             resourcePath: VSpellPoints.resourcesPath(),
             levelsTooltip
+        }
+
+        if (!VSpellPoints.TEMPLATES.hasOwnProperty(sheetTheme)) {
+            sheetTheme = VSpellPoints.CUSTOM_SHEETS.DEFAULT;
         }
 
         let template = VSpellPoints.TEMPLATES[sheetTheme][asResource ? "RESOURCE" : "ATTRIBUTE"];

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -20,8 +20,20 @@ class VSpellPoints {
         return `flags.${VSpellPoints.ID}.${VSpellPoints.FLAGS.RESOURCES}`
     }
 
+    static CUSTOM_SHEETS = {
+        TIDY5E: "Tidy5eSheet"
+    }
+
     static TEMPLATES = {
-        ATTRIBUTE: `modules/${this.ID}/templates/attribute.hbs`
+        LEVELS_TOOLTIP: `modules/${this.ID}/templates/levels-tooltip.hbs`,
+        ActorSheet5e: {
+            ATTRIBUTE: `modules/${this.ID}/templates/attribute.hbs`,
+            RESOURCE: `modules/${this.ID}/templates/attributes.hbs`,
+        },
+        Tidy5eSheet: {
+            ATTRIBUTE: `modules/${this.ID}/templates/tidy5e-attribute.hbs`,
+            RESOURCE: `modules/${this.ID}/templates/tidy5e-resource.hbs`,
+        }
     }
 
     static SETTINGS = {
@@ -416,7 +428,7 @@ class VSpellPointsCalcs {
         return this._spellPointsByLevelTable[clampedLevel];
     }
 
-    static async createSpellPointsInfo(actor, data, asResource= false) {
+    static async createSpellPointsInfo(actor, data, asResource=false, sheetTheme='ActorSheet5e') {
         // read from actor
         /** @type Resource */
         let userData = data;
@@ -429,25 +441,29 @@ class VSpellPointsCalcs {
 
         let [combinedLevel, allCastingLevels] = VSpellPointsCalcs.getCombinedSpellCastingLevel(actor_classes)
 
+        const levelsTooltipData = {
+            allCastingLevels,
+            combinedLevel
+        }
+
+        let levelsTooltip = asResource ? null : await renderTemplate(VSpellPoints.TEMPLATES.LEVELS_TOOLTIP, levelsTooltipData);;
+
         // TODO: with localization
         const template_data =  {
             spellPointsNameText: "Spell Points",
+            spellPointsAbbreviationText: "SP",
             maxSpellPointsTooltip: "Your maximum number of spell points",
             currentSpellpoints: userData.points.value,
             maxSpellPoints: userData.points.max,
-            combinedLevel,
-            allCastingLevels,
             asResource,
             resourcePath: VSpellPoints.resourcesPath(),
+            levelsTooltip
         }
-        // TODO: tidy5e
-        let tidy5e = `<div class="resource-value multiple">
-            <input class="res-value" name="flags.spellpoints5e.resources.points.value" type="text" value="" data-dtype="Number" placeholder="0" maxlength="3">
-            <span class="sep">/</span>
-            <input class="res-max" name="flags.spellpoints5e.resources.points.max" type="text" value="" data-dtype="Number" placeholder="0" maxlength="3">
-        </div>`
 
-        let spellPointsInfo = await renderTemplate(VSpellPoints.TEMPLATES.ATTRIBUTE, template_data);
+        let template = VSpellPoints.TEMPLATES[sheetTheme][asResource ? "RESOURCE" : "ATTRIBUTE"];
+
+        let spellPointsInfo = await renderTemplate(template, template_data);
+
         return spellPointsInfo;
     }
 }
@@ -557,9 +573,22 @@ Hooks.once('ready', () => {
 
         // change header of sheet
         VSpellPoints.log("It's a caster! - Level " + VSpellPointsCalcs.getCombinedSpellCastingLevel(actor_classes)[0])
-        let attributesList = html.find(".sheet-header").find(".attributes")
-        let resourcesList = html.find(".sheet-body .center-pane").find("ul.attributes")
+
+        let sheetTheme = actorsheet.constructor.name;
+        let attributesList;
+        let resourcesList;
+
+        if (sheetTheme === VSpellPoints.CUSTOM_SHEETS.TIDY5E) {
+            VSpellPoints.log("Using Tidy5eSheet");
+            attributesList = html.find(".tidy5e-header").find(".header-attributes");
+            resourcesList = html.find(".sheet-body .center-pane").find("ul.resources");
+        } else {
+            attributesList = html.find(".sheet-header").find(".attributes")
+            resourcesList = html.find(".sheet-body .center-pane").find("ul.attributes")
+        }
+
         if (resourcesList.length === 0) {
+            VSpellPoints.log("Resources list is empty");
             resourcesList = html.find(".sheet-main-wrapper .sheet-main").find("ul.attributes")
         }
 
@@ -571,14 +600,15 @@ Hooks.once('ready', () => {
 
         // create new attribute display in the header or the resource block
         // TODO: shorten this line
-        if (Object.values(VSpellPoints.DISPLAY_CHOICE)[game.settings.get(VSpellPoints.ID,VSpellPoints.SETTINGS.DISPLAY)] === VSpellPoints.DISPLAY_CHOICE.resources) {
-            let spellPointsAttribute = VSpellPointsCalcs.createSpellPointsInfo(actor, actorResources, true);
+        let displayAsResource = Object.values(VSpellPoints.DISPLAY_CHOICE)[game.settings.get(VSpellPoints.ID,VSpellPoints.SETTINGS.DISPLAY)] === VSpellPoints.DISPLAY_CHOICE.resources;
+        let spellPointsAttribute = VSpellPointsCalcs.createSpellPointsInfo(actor, actorResources, displayAsResource, sheetTheme);
+        
+        if (displayAsResource) {
             spellPointsAttribute.then((spellPointsInfo) => {
-                let newAttribute = resourcesList.append(spellPointsInfo);
-                actorsheet.activateListeners($(newAttribute).find(".spellpoints"))
+                let newResource = resourcesList.append(spellPointsInfo);
+                actorsheet.activateListeners($(newResource).find(".spellpoints"))
             })
         } else {
-            let spellPointsAttribute = VSpellPointsCalcs.createSpellPointsInfo(actor, actorResources, false);
             spellPointsAttribute.then((spellPointsInfo) => {
                 let newAttribute = attributesList.append(spellPointsInfo);
                 actorsheet.activateListeners($(newAttribute).find(".spellpoints"))

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -26,9 +26,9 @@ class VSpellPoints {
 
     static TEMPLATES = {
         LEVELS_TOOLTIP: `modules/${this.ID}/templates/levels-tooltip.hbs`,
-        ActorSheet5e: {
+        ActorSheet5eCharacter: {
             ATTRIBUTE: `modules/${this.ID}/templates/attribute.hbs`,
-            RESOURCE: `modules/${this.ID}/templates/attributes.hbs`,
+            RESOURCE: `modules/${this.ID}/templates/attribute.hbs`,
         },
         Tidy5eSheet: {
             ATTRIBUTE: `modules/${this.ID}/templates/tidy5e-attribute.hbs`,
@@ -428,7 +428,7 @@ class VSpellPointsCalcs {
         return this._spellPointsByLevelTable[clampedLevel];
     }
 
-    static async createSpellPointsInfo(actor, data, asResource=false, sheetTheme='ActorSheet5e') {
+    static async createSpellPointsInfo(actor, data, asResource=false, sheetTheme='ActorSheet5eCharacter') {
         // read from actor
         /** @type Resource */
         let userData = data;

--- a/styles/main.css
+++ b/styles/main.css
@@ -41,7 +41,15 @@
     font-weight: normal;
 }
 
-/* for tidySheet5e... TODO: maybe add it programmatically */
+/* 
+ * Tidy5eSheet
+ */
+/* Attributes */
+.tidy5e.sheet.actor .header-attributes .spellpoints:hover .property-attribution {
+    display: block;
+}
+
+/* Spellbook  TODO: maybe add it programmatically */
 .tidy5e.sheet .spellbook-header .spell-level-slots h3.points-variant ,
 .tidy5e.sheet .spellbook-header .spell-level-slots h4.points-variant {
     flex: none !important;

--- a/templates/attribute.hbs
+++ b/templates/attribute.hbs
@@ -5,24 +5,7 @@
         <span class="sep"> / </span>
         <span class="attribute-max" style="padding: 1px 7px !important;" title="{{ maxSpellPointsTooltip }}"> {{ maxSpellPoints }} </span>
         {{#unless asResource }}
-        <div class="property-attribution tooltip">
-            <table>
-                <thead>Spellcasting Levels: </thead>
-                <tbody>
-                {{#each allCastingLevels}}
-                    <tbody><tr>
-                        <td class="attribution-value {{#if @first }} mode-5 {{ else }} mode-2 {{/if}}">
-                            {{ this }}
-                        </td>
-                        <td class="attribution-label">{{ @key }}</td>
-                    </tr>
-                {{/each }}
-                <tr class="total">
-                    <td class="attribution-value">{{ combinedLevel }}</td>
-                    <td class="attribution-label">Total</td>
-                </tr>
-                </tbody></table>
-        </div>
+        {{{ levelsTooltip }}}
         {{/unless}}
     </div>
     <!-- Temp and Max override

--- a/templates/levels-tooltip.hbs
+++ b/templates/levels-tooltip.hbs
@@ -1,0 +1,18 @@
+<div class="property-attribution tooltip">
+    <table>
+        <thead>Spellcasting Levels: </thead>
+        <tbody>
+        {{#each allCastingLevels}}
+            <tr>
+                <td class="attribution-value {{#if @first }} mode-5 {{ else }} mode-2 {{/if}}">
+                    {{ this }}
+                </td>
+                <td class="attribution-label">{{ @key }}</td>
+            </tr>
+        {{/each }}
+        <tr class="total">
+            <td class="attribution-value">{{ combinedLevel }}</td>
+            <td class="attribution-label">Total</td>
+        </tr>
+        </tbody></table>
+</div>

--- a/templates/tidy5e-attribute.hbs
+++ b/templates/tidy5e-attribute.hbs
@@ -1,0 +1,12 @@
+<li class="header-attribute spellpoints">
+    <h4 class="attribute-name" title="{{ spellPointsNameText }}">{{ spellPointsAbbreviationText }}</h4>
+    <div class="value">
+        <input name="{{ resourcePath }}.points.value" type="text" value="{{ currentSpellpoints }}" placeholder="10" data-dtype="Number" /> <!-- title="${currentSpellPointsTooltip}" -->
+    </div>
+    <footer class="value-footer" title="{{ maxSpellPointsTooltip }}">
+        <label for="spellpoints5e-max" title="">Max</label>
+        <input id="spellpoints5e-max" class="ini-mod" name="{{ resourcePath }}.points.max"
+            type="text" placeholder="10" data-dtype="Number" value="{{ maxSpellPoints }}" maxlength="3" disabled />
+    </footer>
+    {{{ levelsTooltip }}}
+</li>

--- a/templates/tidy5e-resource.hbs
+++ b/templates/tidy5e-resource.hbs
@@ -1,0 +1,10 @@
+<li class="resource spellpoints">
+    <h4 class="resource-name">
+        <input type="text" value="{{ spellPointsNameText }}" placeholder="Spell Points" disabled />
+    </h4>
+    <div class="resource-value multiple">
+        <input class="res-value" name="{{ resourcePath }}.points.value" type="text" value="{{ currentSpellpoints }}" data-dtype="Number" placeholder="10" maxlength="3" />
+        <span class="sep">/</span>
+        <input class="res-max" name="{{ resourcePath }}.points.max" type="text" value="{{ maxSpellPoints }}" data-dtype="Number" placeholder="10" maxlength="3" disabled />
+    </div>
+</li>


### PR DESCRIPTION
Adds support for displaying Spell Points as an attribute or a resource in Tidy5e Sheet

## Attribute
* Displays at the end of the header-attributes list, where armour class and initiative are; before the ability scores list.
* Abbreviated spell points to "SP" to fit with the other abbreviations, but it'll display "Spell Points" when you hover over it.
* Supports the same spellcasting levels tooltip that the attributes do on the base sheet. Triggers when you hover over any section of the spell points attribute

![image](https://user-images.githubusercontent.com/43473593/183237157-20ca3a12-7c03-4762-ba81-b8b0b0c69bc6.png)

## Resource
* Appends to the end of the resources block
* Looks a little weird because it's full width on the next row; but squeezing it onto the first row wouldn't be as nice for compatibility with other modules that add resources

![image](https://user-images.githubusercontent.com/43473593/183237048-eddf8fb6-cd61-4f5e-8a70-f827baceed5f.png)

## Other code changes/justifications
* Move the spellcasting levels tooltip html into its own template so it can be easily reused between the default sheet and the Tidy5e Sheet (and any future ones)
* Refactored the `TEMPLATES` model to better support possible future additions of different sheets
* Made Tidy5e's templates two different files 'cause it's easier to read, instead of trying to get them both into the one handlebars file
* Used an `input` element for the maximum spell points value, and set it to `disabled` to stop people from editing it (it would get overridden when the sheet reloads anyway). Tidy5e's css is set up for `input` elements, using a `span` or something else that's static would require us adding new css which I'm trying to avoid for forwards-compatibility

## Known Issues
When displaying spell points as a resource, the resource is only visible if:
* The sheet is unlocked for editing, or
* A custom resource is already in use

If not, the entire resource block disappears as the locked version of the sheet tidies up unused elements. The cleanup code is called in the `renderTidy5eSheet` hook
https://github.com/sdenec/tidy5e-sheet/blob/99bf2912400eb860a99042e02e2adfd7f3c7cbb2/src/scripts/tidy5e-sheet.js#L548-L550
https://github.com/sdenec/tidy5e-sheet/blob/99bf2912400eb860a99042e02e2adfd7f3c7cbb2/src/scripts/tidy5e-sheet.js#L298-L304
which is called before `renderActorSheet5e`. This could be fixed if we could append the spell points resource before/during the `renderTidy5eSheet` hook.

Closes #10