### PR TITLE
Fixed actor selection issue in V10

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -88,6 +88,10 @@ class VSpellPoints {
         })
         return unsupported;
     }
+
+    static isV10() {
+        return !foundry.utils.isNewerVersion(10, game.version ?? game?.data?.version);
+    }
 }
 
 class VSpellPointsData {
@@ -681,11 +685,14 @@ Hooks.once('ready', () => {
         if (!VSpellPointsData.isCharacter(actor) || !VSpellPointsData.isSpellcaster(actor)) return;
 
         // only apply on spells that cost resources
+        let preparation = item?.system?.preparation;
+        if (!preparation) preparation = item?.data?.data?.preparation;
+
         if (item?.data?.type !== "spell"
             || item?.labels?.level === "Cantrip"
-            || item?.data?.data?.preparation?.mode === "atwill"
-            || item?.data?.data?.preparation?.mode === "innate"
-            || html.find("#ability-use-form").find(".form-group").find("select[name=level]").length === 0){
+            || preparation?.mode === "atwill"
+            || preparation?.mode === "innate"
+            || html.find("#ability-use-form").find(".form-group").find(VSpellPoints.isV10() ? "select[name=consumeSpellLevel]" : "select[name=level]").length === 0){
             VSpellPoints.log("not using a resource spell")
             return;
         }
@@ -701,11 +708,11 @@ Hooks.once('ready', () => {
         // change consume spell slot text
         let consumeText = $(html)
             .find("#ability-use-form")
-            .find("input[name='consumeSlot']")
+            .find(VSpellPoints.isV10() ? "input[name='consumeSpellSlot']" : "input[name='consumeSlot']")
             .parent()
             .contents().filter(function () {
                 // get only text elements
-                return this.nodeType === 3;
+                return (this.nodeType === 3 && (this.textContent?.trim().length > 0));
             });
 
         if (VSpellPointsData.isWarlock(actor))
@@ -716,7 +723,7 @@ Hooks.once('ready', () => {
         // modify the "cast at level" list
         $(html)
             .find("#ability-use-form")
-            .find("select[name='level']")
+            .find(VSpellPoints.isV10() ? "select[name=consumeSpellLevel]" : "select[name=level]")
             .find("option")
             .each(function (i) {
                 let spellValue = $(this).attr("value")

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -489,7 +489,7 @@ Hooks.once('ready', () => {
             icon: "fas fa-book",
             onclick: async (event) => {
                 const clickedElement = $(event.currentTarget);
-                const actorID = clickedElement.parents('[id]')?.attr("id")?.replace("actor-", "")
+                const actorID = clickedElement.parents('[id]')?.attr("id")?.split("-").pop()
                 const actor = game.actors.get(actorID)
                 const previousChoice = VSpellPointsData.getPointsEnabled(actor)
                 const selectedAttribute = `selected="selected"`


### PR DESCRIPTION
In V10 the element is prefixed by the type as well `[Type]-actor-[#id]`, this just extracts the end part regardless of the type of the Actor I didn't test on V9 and earlier, but it should still work there.